### PR TITLE
Simplify getPersistentDataContainer

### DIFF
--- a/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
+++ b/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
@@ -384,14 +384,9 @@ public class CustomBlockData implements PersistentDataContainer {
     @NotNull
     private PersistentDataContainer getPersistentDataContainer() {
         final PersistentDataContainer chunkPDC = chunk.getPersistentDataContainer();
-        final PersistentDataContainer blockPDC;
-        if (chunkPDC.has(key, PersistentDataType.TAG_CONTAINER)) {
-            blockPDC = chunkPDC.get(key, PersistentDataType.TAG_CONTAINER);
-            assert blockPDC != null;
-            return blockPDC;
-        }
-        blockPDC = chunkPDC.getAdapterContext().newPersistentDataContainer();
-        return blockPDC;
+        final PersistentDataContainer blockPDC = chunkPDC.get(key, PersistentDataType.TAG_CONTAINER);
+        if (blockPDC != null) return blockPDC;
+        return chunkPDC.getAdapterContext().newPersistentDataContainer();
     }
 
     /**


### PR DESCRIPTION
We noticed a hotspot in getPersistentDataContainer because it's making unnecessary pdc lookups. This PR replaces that with a direct get and null check

![image](https://github.com/mfnalex/CustomBlockData/assets/73862843/6d97fb3a-ce8a-4d1d-a0b4-27fb943865aa)

