### PR TITLE
Preventing the IllegalPluginAccessException when saving a CustomBlockData with a disabled plugin

### DIFF
--- a/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
+++ b/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
@@ -213,11 +213,16 @@ public class CustomBlockData implements PersistentDataContainer {
     }
 
     /**
-     * Sets this block as "dirty" and removes it from the list after the next tick
+     * Sets this block as "dirty" and removes it from the list after the next tick.
+     * <p>
+     * If the plugin is disabled, this method will do nothing, to prevent the IllegalPluginAccessException.
      * @param plugin Plugin
      * @param blockEntry Block entry
      */
     static void setDirty(Plugin plugin, Map.Entry<UUID, BlockVector> blockEntry) {
+        if (!plugin.isEnabled()) //checks if the plugin is disabled to prevent the IllegalPluginAccessException
+            return;
+
         DIRTY_BLOCKS.add(blockEntry);
         Bukkit.getScheduler().runTask(plugin, () -> DIRTY_BLOCKS.remove(blockEntry));
     }


### PR DESCRIPTION
I was developing my plugin when I needed to save the block data when the plugin was being disabled. When I did that, I got a IllegalPluginAccessException. After a little search, I found out that the CustomBlockData.setDirty method was being called and was creating a task, which was raising the IllegalPluginAccessException.
The CustomBlockData.isDirty method is only called inside a BlockPlaceEvent listener, which makes it safe to ignore the CustomBlockData.setDirty method when the plugin is disabled