### PR TITLE
(Feat) Add Folia Support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     compileOnly(libs.paper)
+    compileOnly(libs.folia)
     compileOnly(libs.jetbrains.annotations)
 
     testImplementation(libs.junit.junit)
@@ -26,9 +27,10 @@ dependencies {
 }
 
 group = "com.jeff-media"
-version = "2.2.4"
+version = "2.2.5"
 description = "CustomBlockData"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.disableAutoTargetJvm()
 
 java {
     withSourcesJar()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 
 [versions]
 mockbukkit = "3.1.0"
-paper = "1.19.3-R0.1-SNAPSHOT"
+paper = "1.20.1-R0.1-SNAPSHOT"
 junit-junit = "4.13.2"
 org-jetbrains-annotations = "24.0.0"
 org-slf4j-slf4j-simple = "2.0.6"
@@ -11,6 +11,7 @@ org-slf4j-slf4j-simple = "2.0.6"
 [libraries]
 mockbukkit = { module = "com.github.seeseemelk:MockBukkit-v1.19", version.ref = "mockbukkit" }
 paper = { module = "io.papermc.paper:paper-api", version.ref = "paper" }
+folia = { module = "dev.folia:folia-api", version.ref = "paper" }
 junit-junit = { module = "junit:junit", version.ref = "junit-junit" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "org-jetbrains-annotations" }
 slf4j = { module = "org.slf4j:slf4j-simple", version.ref = "org-slf4j-slf4j-simple" }

--- a/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
+++ b/src/main/java/com/jeff_media/customblockdata/CustomBlockData.java
@@ -108,8 +108,16 @@ public class CustomBlockData implements PersistentDataContainer {
      */
     private static final boolean HAS_MIN_HEIGHT_METHOD;
 
+    private static boolean onFolia;
+
     static {
         checkRelocation();
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            onFolia = true;
+        } catch (ClassNotFoundException e) {
+            onFolia = false;
+        }
     }
 
     static {
@@ -224,7 +232,13 @@ public class CustomBlockData implements PersistentDataContainer {
             return;
 
         DIRTY_BLOCKS.add(blockEntry);
-        Bukkit.getScheduler().runTask(plugin, () -> DIRTY_BLOCKS.remove(blockEntry));
+        if (onFolia) {
+            Bukkit.getServer().getGlobalRegionScheduler().runDelayed(plugin, task -> {
+                DIRTY_BLOCKS.remove(blockEntry);
+            }, 1L);
+        } else {
+            Bukkit.getScheduler().runTask(plugin, () -> DIRTY_BLOCKS.remove(blockEntry));
+        }
     }
 
     /**


### PR DESCRIPTION
This is a continuation of #16 The reason for using a static variable rather than a library for the folia support is to prevent unnecessary overhead from extra files and libraries, given it's only the one place it's accessed and only Folia which has the scheduling issues.

If you wish to use a library, let me know, and I'll convert it to use it instead.